### PR TITLE
Remove examples from the distributed npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "browser": "dist/workerpool.js",
   "files": [
     "dist",
-    "examples",
     "src",
     "HISTORY.md",
     "LICENSE",


### PR DESCRIPTION
I don't think that the examples should be distributed through `npm`. The're standalone programs, so it' unlikely that someone will require them (eg. `require('workerpool/examples/async.js')`), and because there's a `package-lock.json` inside one of the examples, it can confuse security scanners that are looking for vulnerable packages.